### PR TITLE
Improvements

### DIFF
--- a/client.winforms/OneTrueError.Client.WinForms/FormScreenshooter.cs
+++ b/client.winforms/OneTrueError.Client.WinForms/FormScreenshooter.cs
@@ -65,7 +65,8 @@ namespace OneTrueError.Client.WinForms
 
             Capture(form, ms);
             var str = Convert.ToBase64String(ms.GetBuffer(), 0, (int) ms.Length);
-            screenshots.Add(Guid.NewGuid().ToString(), str);
+            var name = GetFormName(screenshots, form);
+            screenshots.Add(name, str);
             return new ContextCollectionDTO(ScreenshotProvider.NAME, screenshots);
         }
 
@@ -83,7 +84,8 @@ namespace OneTrueError.Client.WinForms
             {
                 Capture(Form.ActiveForm, ms);
                 var str = Convert.ToBase64String(ms.GetBuffer(), 0, (int) ms.Length);
-                screenshots.Add(Guid.NewGuid().ToString(), str);
+                var name = GetFormName(screenshots, Form.ActiveForm);
+                screenshots.Add(name, str);
             }
             
             foreach (Form form in Application.OpenForms)
@@ -95,10 +97,23 @@ namespace OneTrueError.Client.WinForms
                 ms.SetLength(0);
                 Capture(form, ms);
                 var str = Convert.ToBase64String(ms.GetBuffer(), 0, (int) ms.Length);
-                screenshots.Add(Guid.NewGuid().ToString(), str);
+                var name = GetFormName(screenshots, form)
+                screenshots.Add(name, str);
             }
 
             return new ContextCollectionDTO(ScreenshotProvider.NAME, screenshots);
         }
+        
+        private static string GetFormName(IDictionary<string,string> screenshots, Form form)		
+-       {		
+-            var name = form.Name;		
+-            if (string.IsNullOrEmpty(name))		
+-                name = string.IsNullOrEmpty(form.Text) ? "Noname": form.Text;
+
+             if (screenshots.ContainsKey(name))
+                name = string.Format("{0}{1}",name,Guid.NewGuid().ToString());
+
+-            return name;		
+-        }
     }
 }

--- a/client.winforms/OneTrueError.Client.WinForms/FormScreenshooter.cs
+++ b/client.winforms/OneTrueError.Client.WinForms/FormScreenshooter.cs
@@ -65,8 +65,7 @@ namespace OneTrueError.Client.WinForms
 
             Capture(form, ms);
             var str = Convert.ToBase64String(ms.GetBuffer(), 0, (int) ms.Length);
-            var name = GetFormName(form);
-            screenshots.Add(name, str);
+            screenshots.Add(Guid.NewGuid().ToString(), str);
             return new ContextCollectionDTO(ScreenshotProvider.NAME, screenshots);
         }
 
@@ -84,11 +83,9 @@ namespace OneTrueError.Client.WinForms
             {
                 Capture(Form.ActiveForm, ms);
                 var str = Convert.ToBase64String(ms.GetBuffer(), 0, (int) ms.Length);
-                var name = GetFormName(Form.ActiveForm);
-                screenshots.Add(name, str);
+                screenshots.Add(Guid.NewGuid().ToString(), str);
             }
-
-
+            
             foreach (Form form in Application.OpenForms)
             {
                 if (form == Form.ActiveForm)
@@ -98,23 +95,10 @@ namespace OneTrueError.Client.WinForms
                 ms.SetLength(0);
                 Capture(form, ms);
                 var str = Convert.ToBase64String(ms.GetBuffer(), 0, (int) ms.Length);
-                var name = GetFormName(form);
-                screenshots.Add(name, str);
+                screenshots.Add(Guid.NewGuid().ToString(), str);
             }
 
             return new ContextCollectionDTO(ScreenshotProvider.NAME, screenshots);
-        }
-
-        private static string GetFormName(Form form)
-        {
-            var name = form.Name;
-            if (string.IsNullOrEmpty(name))
-            {
-                name = string.IsNullOrEmpty(form.Text)
-                    ? "Noname"
-                    : form.Text;
-            }
-            return name;
         }
     }
 }


### PR DESCRIPTION
Fixed the potential key collision issue in GetFormName - where Text can be String.Empty or null (in library assembly for instance)
Replaced the whole function with a Guid.NewGuid().ToString() as key in the screenshot dictionary