### PR TITLE
IEnumerable collections have an extra dot in prefix

### DIFF
--- a/client/OneTrueError.Client/Converters/ObjectToContextCollectionConverter.cs
+++ b/client/OneTrueError.Client/Converters/ObjectToContextCollectionConverter.cs
@@ -303,8 +303,8 @@ namespace OneTrueError.Client.Converters
                         foreach (var item in items)
                         {
                             var newPrefix = prefix == ""
-                                ? string.Format("{0}[{1}].", propertyName, index)
-                                : string.Format("{0}{1}[{2}].", prefix, propertyName, index);
+                                ? string.Format("{0}[{1}]", propertyName, index)
+                                : string.Format("{0}{1}[{2}]", prefix, propertyName, index);
                             ReflectValue(newPrefix, item, contextCollection, path);
                             index++;
                         }


### PR DESCRIPTION
The IEnumerable collections have an extra dot in the prefix when reflected i.e.
Collection[0]..PropertyName

Fixed it so that it is coherent